### PR TITLE
leam-base.joda-time.mid-2570.idx-178564.9.mutant

### DIFF
--- a/joda-time/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
+++ b/joda-time/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
@@ -111,8 +111,9 @@ public class CachedDateTimeZone extends DateTimeZone {
     }
 
     @Override
-        public boolean isFixed() {
-    return iZone.isFixed();    }
+    public boolean isFixed() {
+        return iZone.isFixed();    
+    }
 
     @Override
     public long nextTransition(long instant) {


### PR DESCRIPTION
The file `joda-time/src/main/java/org/joda/time/tz/CachedDateTimeZone.java` had indentation and spacing inconsistency on lines 114-116. Fixed the issue.