### PR TITLE
codebert-base.commons-lang.mid-2202.idx-18905.1.buggy

### DIFF
--- a/commons-lang/src/main/java/org/apache/commons/lang3/mutable/MutableByte.java
+++ b/commons-lang/src/main/java/org/apache/commons/lang3/mutable/MutableByte.java
@@ -168,7 +168,10 @@ public class MutableByte extends Number implements Comparable<MutableByte>, Muta
      * @return the value associated with the instance after it is decremented
      * @since 3.5
      */
-    public byte decrementAndGet() { int newValue = value - 1; return (byte) newValue; // bug2: return a casted value of newValue instead of value }
+    public byte decrementAndGet() { 
+        int newValue = value - 1;
+        return (byte) newValue; // bug2: return a casted value of newValue instead of value 
+    }
 
     /**
      * Adds a value to the value of this instance.


### PR DESCRIPTION
fixed spacing and unmatched parenthesis in  file `commons-lang/src/main/java/org/apache/commons/lang3/mutable/MutableByte.java`