### PR TITLE
codet5-base.commons-lang.mid-2431.idx-16692.2.buggy

### DIFF
--- a/commons-lang/src/main/java/org/apache/commons/lang3/mutable/MutableLong.java
+++ b/commons-lang/src/main/java/org/apache/commons/lang3/mutable/MutableLong.java
@@ -90,7 +90,10 @@ public class MutableLong extends Number implements Comparable<MutableLong>, Muta
      *
      * @param value  the value to set
      */
-    public void setValue(final long value) { //Buggy version 1 this.value -= value; // Subtraction instead of assignment }
+    public void setValue(final long value) {
+        //Buggy version 1 
+        this.value -= value; // Subtraction instead of assignment
+    }
 
     /**
      * Sets the value from any Number instance.


### PR DESCRIPTION
Previous version of `commons-lang/src/main/java/org/apache/commons/lang3/mutable/MutableLong.java` was not compilable. Now can be compiled and fixed indentations