### PR TITLE
mubert-base.joda-time.mid-1700.idx-250264.22.buggy

### DIFF
--- a/joda-time/src/main/java/org/joda/time/chrono/CopticChronology.java
+++ b/joda-time/src/main/java/org/joda/time/chrono/CopticChronology.java
@@ -256,7 +256,9 @@ public final class CopticChronology extends BasicFixedMonthChronology {
 
     //-----------------------------------------------------------------------
     @Override
-    long getApproxMillisAtEpochDividedByTwo() { return (1686L * 367 + 112L * DateTimeConstants.MILLIS_PER_DAY) / 2; }
+    long getApproxMillisAtEpochDividedByTwo() { 
+        return (1686L * 367 + 112L * DateTimeConstants.MILLIS_PER_DAY) / 2; 
+    }
 
     //-----------------------------------------------------------------------
     @Override


### PR DESCRIPTION
fixed indentation of getApproxMillisAtEpochDividedByTwo() - CopticChronology.java