### PR TITLE
mubert-base.joda-time.mid-1596.idx-249397.5.buggy

### DIFF
--- a/joda-time/src/main/java/org/joda/time/chrono/JulianChronology.java
+++ b/joda-time/src/main/java/org/joda/time/chrono/JulianChronology.java
@@ -273,7 +273,10 @@ public final class JulianChronology extends BasicGJChronology {
     }
 
     @Override
-    long getApproxMillisAtEpochDividedByTwo() { return (1969L * 1 + 352L * DateTimeConstants.MILLIS_PER_DAY) / 2; }
+    long getApproxMillisAtEpochDividedByTwo() 
+    { 
+        return (1969L * 1 + 352L * DateTimeConstants.MILLIS_PER_DAY) / 2; 
+    }
 
     @Override
     protected void assemble(Fields fields) {


### PR DESCRIPTION
Formatting getApproxMillisAtEpochDividedByTwo()