### PR TITLE
mubert-base.joda-time.mid-1596.idx-249397.40.mutant

### DIFF
--- a/joda-time/src/main/java/org/joda/time/chrono/JulianChronology.java
+++ b/joda-time/src/main/java/org/joda/time/chrono/JulianChronology.java
@@ -273,9 +273,9 @@ public final class JulianChronology extends BasicGJChronology {
     }
 
     @Override
-        long getApproxMillisAtEpochDividedByTwo() {
-            return (1969L * MILLIS_PER_YEAR +  1 * DateTimeConstants.MILLIS_PER_DAY) / 2;
-        }
+    long getApproxMillisAtEpochDividedByTwo() {
+        return (1969L * MILLIS_PER_YEAR +  1 * DateTimeConstants.MILLIS_PER_DAY) / 2;
+    }
     
 
     @Override


### PR DESCRIPTION
Reformatted the getApproxMillisAtEpochDividedByTwo method