### PR TITLE
codet5-base.jackson-databind.mid-5390.idx-39934.3.buggy

### DIFF
--- a/jackson-databind/src/main/java/com/fasterxml/jackson/databind/node/IntNode.java
+++ b/jackson-databind/src/main/java/com/fasterxml/jackson/databind/node/IntNode.java
@@ -107,7 +107,8 @@ public class IntNode
     }
 
     @Override
-    public boolean asBoolean(boolean defaultValue) { return _value == 0; // Changed from != to == }
+    public boolean asBoolean(boolean defaultValue) {
+        return _value == 0; // Changed from != to == }
 
     @Override
     public final void serialize(JsonGenerator g, SerializerProvider provider)


### PR DESCRIPTION
Reformatted the asBoolean method

Note: The buggy code contains a syntax error as the closing brace of the method is not present. Since this task involved purely formatting changes, I have not corrected the method code by adding a closing brace.