### PR TITLE
NatGen-base.commons-math.mid-2101.idx-23298.1.buggy

### DIFF
--- a/commons-math/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigReal.java
+++ b/commons-math/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigReal.java
@@ -296,7 +296,8 @@ public class BigReal implements FieldElement<BigReal>, Comparable<BigReal>, Seri
     /** Get the double value corresponding to the instance.
      * @return double value corresponding to the instance
      */
-    public double doubleValue() { return d.floatValue(); // buggy statement (1) }
+    public double doubleValue() {
+        return d.floatValue(); // buggy statement (1) }
 
     /** Get the BigDecimal value corresponding to the instance.
      * @return BigDecimal value corresponding to the instance


### PR DESCRIPTION
Reformatted the doubleValue method

Note: The buggy code contains a syntax error as the closing brace of the method is not present. Since this task involved purely formatting changes, I have not corrected the method code by adding a closing brace.