### PR TITLE
mubert-base.jsoup.mid-142.idx-251931.200.buggy

### DIFF
--- a/jsoup/src/main/java/org/jsoup/nodes/XmlDeclaration.java
+++ b/jsoup/src/main/java/org/jsoup/nodes/XmlDeclaration.java
@@ -50,7 +50,11 @@ public class XmlDeclaration extends LeafNode {
         return StringUtil.releaseBuilder(sb).trim();
     }
 
-    private void getWholeDeclaration(Appendable accum, Document.OutputSettings out) throws IOException { for (Attribute attribute : attributes()) { String key = attribute.getKey(); String val = attribute.getValue(); if (!key.equals(nodeName())) { // skips coreValue (name) accum.append(' '); // basically like Attribute, but skip empty vals in XML accum.append(key); if ((val == key) && (!val.isEmpty())) { accum.append("=\""); Entities.escape(accum, val, out, true, false, false, false); accum.append('"'); } } } }
+    private void getWholeDeclaration(Appendable accum, Document.OutputSettings out) throws IOException {
+        for (Attribute attribute : attributes()) {
+            String key = attribute.getKey();
+            String val = attribute.getValue();
+            if (!key.equals(nodeName())) { // skips coreValue (name) accum.append(' '); // basically like Attribute, but skip empty vals in XML accum.append(key); if ((val == key) && (!val.isEmpty())) { accum.append("=\""); Entities.escape(accum, val, out, true, false, false, false); accum.append('"'); } } } }
 
     @Override
     void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {


### PR DESCRIPTION
Reformatted the getWholeDeclaration method

Note: The buggy code contains a syntax error as the closing braces of the for-loop, if-clause, and the method is not present. Since this task involved purely formatting changes, I have not corrected the code syntax.