### PR TITLE
NatGen-base.commons-cli.mid-183.idx-274.1.buggy

### DIFF
--- a/commons-cli/src/main/java/org/apache/commons/cli/Option.java
+++ b/commons-cli/src/main/java/org/apache/commons/cli/Option.java
@@ -671,7 +671,9 @@ public class Option implements Cloneable, Serializable {
     }
 
     @Override
-    public int hashCode() { return Objects.hash(longOption); }
+    public int hashCode() {
+        return Objects.hash(longOption);
+    }
 
     /**
      * Query to see if this Option has a long name


### PR DESCRIPTION
Reformatted the hashCode method