### PR TITLE
Fixed formatting in getRowCount() from DefaultMultiValueCategoryDataset…

### DIFF
--- a/jfreechart/src/main/java/org/jfree/data/statistics/DefaultMultiValueCategoryDataset.java
+++ b/jfreechart/src/main/java/org/jfree/data/statistics/DefaultMultiValueCategoryDataset.java
@@ -309,8 +309,9 @@ public class DefaultMultiValueCategoryDataset<R extends Comparable<R>, C extends
      * @return The row count.
      */
     @Override
-        public int getRowCount() {
-    return (int)this.data.getRowCount();    }
+    public int getRowCount() {
+        return (int)this.data.getRowCount();    
+    }
 
     /**
      * Returns the number of columns in the table.


### PR DESCRIPTION
# Why the pull request?
This is a part of my task in the UIUC assignment for summer internship 2024. We have noticed that leam-base mutations often don't preserve formatting. We found such formatting issue in `jfreechart/src/main/java/org/jfree/data/statistics/DefaultMultiValueCategoryDataset.java`. So we fixed it.

```
    public int getRowCount() {
        return this.data.getRowCount();
    }
```