### PR TITLE
 Fixed formatting in getUnitMillis() from ScaledDurationField

### DIFF
--- a/joda-time/src/main/java/org/joda/time/field/ScaledDurationField.java
+++ b/joda-time/src/main/java/org/joda/time/field/ScaledDurationField.java
@@ -118,8 +118,9 @@ public class ScaledDurationField extends DecoratedDurationField {
     }
 
     @Override
-        public long getUnitMillis() {
-    return this.iScalar;    }
+    public long getUnitMillis() {
+        return this.iScalar;    
+    }
 
     //-----------------------------------------------------------------------
     /**


### PR DESCRIPTION
# Why the pull request?
This is a part of my task in the UIUC assignment for summer internship 2024. We have noticed that leam-base mutations often don't preserve formatting. We found such formatting issue in `joda-time/src/main/java/org/joda/time/field/ScaledDurationField.java`. So we fixed it.

```
    @Override
    public long getUnitMillis() {
        return this.iScalar;   
   }
```