### PR TITLE
Fixed formatting in getDefault() from PeriodFormat.java

### DIFF
--- a/joda-time/src/main/java/org/joda/time/format/PeriodFormat.java
+++ b/joda-time/src/main/java/org/joda/time/format/PeriodFormat.java
@@ -69,8 +69,9 @@ public class PeriodFormat {
      * 
      * @return the formatter, not null
      */
-        public static PeriodFormatter getDefault() {
-    return wordBased(Locale.ENGLISH);    }
+    public static PeriodFormatter getDefault() {
+        return wordBased(Locale.ENGLISH);    
+    }
 
     /**
      * Returns a word based formatter for the JDK default locale.


### PR DESCRIPTION
# Why the pull request?
This is a part of my task in the UIUC assignment for summer internship 2024. We have noticed that leam-base mutations often don't preserve formatting. We found such formatting issue in `joda-time/src/main/java/org/joda/time/format/PeriodFormat.java`. So we fixed it.

```
    public static PeriodFormatter getDefault() {
        return wordBased(Locale.ENGLISH);
    }
```